### PR TITLE
SS-15233 - Bringing in custom SS logic into updated Gotenberg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download &&\
 COPY cmd ./cmd
 COPY pkg ./pkg
 
-RUN go build -o gotenberg -ldflags "-X 'github.com/sortspke/gotenberg2/v8/cmd.Version=$GOTENBERG_VERSION'" cmd/gotenberg/main.go
+RUN go build -o gotenberg -ldflags "-X 'github.com/sortspoke/gotenberg2/v8/cmd.Version=$GOTENBERG_VERSION'" cmd/gotenberg/main.go
 
 # ----------------------------------------------
 # Final stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # ARG instructions do not create additional layers. Instead, next layers will
 # concatenate them. Also, we have to repeat ARG instructions in each build
 # stage that uses them.
-ARG GOLANG_VERSION
+ARG GOLANG_VERSION=1.22
 
 # ----------------------------------------------
 # Gotenberg binary build stage
 # ----------------------------------------------
 FROM golang:$GOLANG_VERSION AS binary-stage
 
-ARG GOTENBERG_VERSION
+ARG GOTENBERG_VERSION=snapshot
 ENV CGO_ENABLED=0
 
 # Define the working directory outside of $GOPATH (we're using go modules).
@@ -24,18 +24,18 @@ RUN go mod download &&\
 COPY cmd ./cmd
 COPY pkg ./pkg
 
-RUN go build -o gotenberg -ldflags "-X 'github.com/gotenberg/gotenberg/v8/cmd.Version=$GOTENBERG_VERSION'" cmd/gotenberg/main.go
+RUN go build -o gotenberg -ldflags "-X 'github.com/sortspke/gotenberg2/v8/cmd.Version=$GOTENBERG_VERSION'" cmd/gotenberg/main.go
 
 # ----------------------------------------------
 # Final stage
 # ----------------------------------------------
 FROM debian:12-slim
 
-ARG GOTENBERG_VERSION
-ARG GOTENBERG_USER_GID
-ARG GOTENBERG_USER_UID
-ARG NOTO_COLOR_EMOJI_VERSION
-ARG PDFTK_VERSION
+ARG GOTENBERG_VERSION=snapshot
+ARG GOTENBERG_USER_GID=1001
+ARG GOTENBERG_USER_UID=1001
+ARG NOTO_COLOR_EMOJI_VERSION=v2.042
+ARG PDFTK_VERSION=v3.3.3
 ARG TMP_CHOMIUM_VERSION_ARMHF="116.0.5845.180-1~deb12u1"
 
 LABEL org.opencontainers.image.title="Gotenberg" \

--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -131,6 +131,10 @@ type Options struct {
 	// PdfFormats allows to convert the resulting PDF to PDF/A-1b, PDF/A-2b,
 	// PDF/A-3b and PDF/UA.
 	PdfFormats gotenberg.PdfFormats
+
+	// Allows the passing in of a password for a password-protected office doc.
+	// Optional.
+	Password string
 }
 
 // DefaultOptions returns the default values for Options.

--- a/pkg/modules/libreoffice/api/libreoffice.go
+++ b/pkg/modules/libreoffice/api/libreoffice.go
@@ -273,6 +273,10 @@ func (p *libreOfficeProcess) pdf(ctx context.Context, logger *zap.Logger, inputP
 		args = append(args, "--export", fmt.Sprintf("PageRange=%s", options.PageRanges))
 	}
 
+	if options.Password != "" {
+		args = append(args, "--password", options.Password)
+	}
+
 	args = append(args, "--export", fmt.Sprintf("ExportFormFields=%t", options.ExportFormFields))
 	args = append(args, "--export", fmt.Sprintf("AllowDuplicateFieldNames=%t", options.AllowDuplicateFieldNames))
 	args = append(args, "--export", fmt.Sprintf("ExportBookmarks=%t", options.ExportBookmarks))

--- a/pkg/modules/libreoffice/routes.go
+++ b/pkg/modules/libreoffice/routes.go
@@ -54,6 +54,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				pdfua                           bool
 				nativePdfFormats                bool
 				merge                           bool
+				password                        string
 				metadata                        map[string]interface{}
 			)
 
@@ -122,6 +123,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 				Bool("pdfua", &pdfua, false).
 				Bool("nativePdfFormats", &nativePdfFormats, true).
 				Bool("merge", &merge, false).
+				String("password", &password, "").
 				Custom("metadata", func(value string) error {
 					if len(value) > 0 {
 						err := json.Unmarshal([]byte(value), &metadata)
@@ -167,6 +169,7 @@ func convertRoute(libreOffice libreofficeapi.Uno, engine gotenberg.PdfEngine) ap
 					Quality:                         quality,
 					ReduceImageResolution:           reduceImageResolution,
 					MaxImageResolution:              maxImageResolution,
+					Password:                        password,
 				}
 
 				if nativePdfFormats {


### PR DESCRIPTION
Brings over custom functionality into updated Gotenberg.
Based on changes from the following approved PRs:
https://github.com/sortspoke/gotenberg/pull/2/files
https://github.com/sortspoke/gotenberg/pull/1/files

Tested importing Excel files, Docx files, and eml files, as well as Password Protected office docs (which is what our custom logic is for).